### PR TITLE
Add runGitHubNotApiClientM to run on gtihub.com

### DIFF
--- a/src/Network/GitHub.hs
+++ b/src/Network/GitHub.hs
@@ -45,6 +45,7 @@ module Network.GitHub
     -- $github
     , GitHub
     , runGitHubClientM
+    , runGitHubNotApiClientM
     , runGitHub'
     , runGitHub
     , AuthToken


### PR DESCRIPTION
Most of the time we must use api.github.com, but calling
login/oauth/access_token only works if sent to github.com.