### PR TITLE
Update to work with latest jose

### DIFF
--- a/servant-github.cabal
+++ b/servant-github.cabal
@@ -52,6 +52,8 @@ library
                      , text
                      , time
                      , transformers
+                     , lens
+                     , mtl
   default-language:    Haskell2010
 
 executable test

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.16
+resolver: lts-9.11
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: [ http-link-header-1.0.1 ]
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
It seems like the JWT-related code in `GitHub.hs` was written against `jose` prior to v6; although I couldn't successfully compile the project even if I choose one of its v5 versions (e.g., 5.0.5) as dependency.

As a result I went in and updated the parts of the code against the latest `jose` and also bumped the stack config.