### PR TITLE
Support servant-client-0.13.x

### DIFF
--- a/servant-github.cabal
+++ b/servant-github.cabal
@@ -53,7 +53,7 @@ library
                      , http-media
                      , jose
                      , servant
-                     , servant-client >= 0.9 && < 0.12
+                     , servant-client >= 0.13 && < 0.14
                      , text
                      , time
                      , transformers

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-9.11
+resolver: lts-11.4
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
I've added a bound to require servant-client 0.13.x, would you like to keep support for eariler versions?

cc @finlay 